### PR TITLE
feat: resolves #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 All instructions can be found at [draculatheme.com/joplin](https://draculatheme.com/joplin).
 
+## Syntax highlight (optional)
+
+Copy the content of `userstyle.css` and paste into your `userstyle.css` file to make syntax highlight using Dracula color scheme.
+
+See [the documentation to customize rendered Markdown](https://joplinapp.org/help/apps/custom_css/) to find where your `userstyle.css` file is located.
+
 ## Team
 
 This theme is maintained by the following person(s) and a bunch of [awesome contributors](https://github.com/dracula/joplin/graphs/contributors).

--- a/userstyle.css
+++ b/userstyle.css
@@ -1,0 +1,76 @@
+/* For styling the rendered Markdown */
+
+/* =============================================================================
+ * Syntax highlight
+ * =============================================================================
+ */
+
+.hljs {
+    color: #f8f8f2;
+    background: #282a36;
+    border: 1px solid #bd93f9;
+    padding: 1em;
+}
+
+.hljs-built_in,
+.hljs-selector-tag,
+.hljs-section,
+.hljs-link {
+    color: #8be9fd;
+}
+
+.hljs-keyword {
+    color: #ff79c6;
+}
+
+.hljs,
+.hljs-subst {
+    color: #f8f8f2;
+}
+
+.hljs-title,
+.hljs-attr,
+.hljs-meta-keyword {
+    font-style: italic;
+    color: #50fa7b;
+}
+
+.hljs-string,
+.hljs-meta,
+.hljs-name,
+.hljs-type,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition,
+.hljs-variable,
+.hljs-template-tag,
+.hljs-template-variable {
+    color: #f1fa8c;
+}
+
+.hljs-comment,
+.hljs-quote,
+.hljs-deletion {
+    color: #6272a4;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-title,
+.hljs-section,
+.hljs-doctag,
+.hljs-type,
+.hljs-name,
+.hljs-strong {
+    font-weight: bold;
+}
+
+.hljs-literal,
+.hljs-number {
+    color: #bd93f9;
+}
+
+.hljs-emphasis {
+    font-style: italic;
+}

--- a/userstyle.css
+++ b/userstyle.css
@@ -1,15 +1,22 @@
 /* For styling the rendered Markdown */
 
-/* =============================================================================
- * Syntax highlight
- * =============================================================================
+/* Dracula Theme v1.2.5
+ *
+ * https://github.com/dracula/highlightjs
+ *
+ * Copyright 2016-present, All rights reserved
+ *
+ * Code licensed under the MIT license
+ *
+ * @author Denis Ciccale <dciccale@gmail.com>
+ * @author Zeno Rocha <hi@zenorocha.com>
  */
 
 .hljs {
-    color: #f8f8f2;
-    background: #282a36;
-    border: 1px solid #bd93f9;
-    padding: 1em;
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #282a36;
 }
 
 .hljs-built_in,


### PR DESCRIPTION
Add color scheme settings to use Dracula color palette for syntax highlighting in code blocks

### Results

<img width="1725" alt="Tangkapan Layar 2024-02-18 pukul 4 15 49 PM" src="https://github.com/dracula/joplin/assets/3760093/e648b2d8-e168-444e-bafe-3e88bebdf500">
